### PR TITLE
OSX's bind should only be applied with legacy readline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ Thanks for Jabba Laci for taking time to report an issue on github.
 * **Jeff Bisbee** http://jbisbee.blogspot.com/
 * **Geoff Ford** http://geoffford.wordpress.com/
 * **Jabba Laci** https://github.com/jabbalaci - issue on github should have been {0} in string format instead of {1}
+* **Kevin Deldycke** http://kevin.deldycke.com

--- a/pythonstartup.py
+++ b/pythonstartup.py
@@ -13,7 +13,9 @@ except ImportError as exception:
     print('Shell Enhancement module problem: {0}').format(exception)
 else:
     # Enable Tab Completion
-    if sys.platform == 'darwin':     # different bind for OSX
+    # OSX's bind should only be applied with legacy readline.
+    if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
+
         readline.parse_and_bind("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")


### PR DESCRIPTION
This fixes the case in which a user installed GNU's `readline` under OSX (with `homebrew` for example).

This case is detailed on StackOverflow: http://stackoverflow.com/a/7116997
