### PR TITLE
Support Python 3 in exception message

### DIFF
--- a/pythonstartup.py
+++ b/pythonstartup.py
@@ -10,7 +10,7 @@ try:
     import sys
     import platform
 except ImportError as exception:
-    print('Shell Enhancement module problem: {0}').format(exception)
+    print('Shell Enhancement module problem: {0}'.format(exception))
 else:
     # Enable Tab Completion
     # OSX's bind should only be applied with legacy readline.


### PR DESCRIPTION
The expression `print('x').format(...)` in Python 3 is equivalent to `(print('x')).format(...)`, which will fail because `print` returns `None`. The intention was obviously to format the string, not the return value of `print`.